### PR TITLE
Change spreadsheet export to use csv

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,9 +40,7 @@ gem 'turbolinks'
 gem 'jbuilder', '~> 2.0'
 # bundle exec rake doc:rails generates the API under doc/api.
 gem 'sdoc', '~> 0.4.0', group: :doc
-# Generate Excel spreadsheets.
-gem 'spreadsheet', '~> 1.0.3'
-# Delayed jobs are used to generate Excel spreadsheets.
+# Delayed jobs are used to generate csv files.
 gem 'delayed_job_active_record', '~> 4.0.3'
 # React JS integration.
 gem 'react-rails', '~> 1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -224,7 +224,6 @@ GEM
       rspec-mocks (~> 3.0.0)
       rspec-support (~> 3.0.0)
     rspec-support (3.0.4)
-    ruby-ole (1.2.11.8)
     safe_yaml (1.0.3)
     sass (3.2.19)
     sass-rails (4.0.3)
@@ -238,8 +237,6 @@ GEM
     simple_form (3.0.2)
       actionpack (~> 4.0)
       activemodel (~> 4.0)
-    spreadsheet (1.0.4)
-      ruby-ole (>= 1.0)
     spring (1.1.3)
     spring-commands-rspec (1.0.4)
       spring (>= 0.9.1)
@@ -309,7 +306,6 @@ DEPENDENCIES
   sass-rails (~> 4.0.3)
   sdoc (~> 0.4.0)
   simple_form
-  spreadsheet (~> 1.0.3)
   spring
   spring-commands-rspec
   turbolinks

--- a/app/controllers/log_spreadsheets_controller.rb
+++ b/app/controllers/log_spreadsheets_controller.rb
@@ -17,6 +17,6 @@ class LogSpreadsheetsController < ApplicationController
       render nothing: true, status: 400
       return
     end
-    send_data spreadsheet.file.force_encoding('binary'), filename: 'logs.xls'
+    send_data spreadsheet.file.force_encoding('binary'), filename: "logs-#{spreadsheet.id}.csv", type: 'text/csv'
   end
 end


### PR DESCRIPTION
Switches Excel spreadsheet generation to csv which is written to the database in chunks to avoid out of memory errors on Heroku.  The database write is done in raw SQL and uses Postgres byte array concatenation operator (||).  During the generate processing loop the updates skip reloading the concatenated byte array to save time and space.  The final update of remaining csv data causes the byte array data to be reloaded so the model has the correct final value.
