### PR TITLE
Changed log_spreadsheets file column to text to avoid encoding errors

### DIFF
--- a/db/migrate/20151014141155_change_file_to_text.rb
+++ b/db/migrate/20151014141155_change_file_to_text.rb
@@ -1,0 +1,5 @@
+class ChangeFileToText < ActiveRecord::Migration
+  def change
+    change_column :log_spreadsheets, :file, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150915175057) do
+ActiveRecord::Schema.define(version: 20151014141155) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -88,7 +88,7 @@ ActiveRecord::Schema.define(version: 20150915175057) do
     t.string   "status"
     t.string   "status_msg"
     t.text     "query"
-    t.binary   "file"
+    t.text     "file"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.boolean  "all_columns", default: false, null: false


### PR DESCRIPTION
After failing to get the exec_query parameters to properly cast the csv data to binary to avoid byte array encoding errors I converted the column to text since the csv data is text already.

I also reversed the default value for the append_to_file method to resolve the double negative "reload() unless skip...".
