### PR TITLE
Increase limit of the logs export 

### DIFF
--- a/app/assets/javascripts/components/log_spreadsheet_export.jsx
+++ b/app/assets/javascripts/components/log_spreadsheet_export.jsx
@@ -180,7 +180,7 @@ modulejs.define('components/log_spreadsheet_export', [], function () {
                 <p>{this.props.downloadEnabled ? "Use the button below to download exported logs." : ""}</p>
               </div>
               <div className="modal-footer">
-                <a type="button" href={this.props.filePath} id="download-spreadsheet" className="btn btn-primary"
+                <a type="button" target="_blank" href={this.props.filePath} id="download-spreadsheet" className="btn btn-primary"
                    disabled={!this.props.downloadEnabled} onClick={this.downloadHandler}>Download spreadsheet</a>
               </div>
             </div>

--- a/app/controllers/log_spreadsheets_controller.rb
+++ b/app/controllers/log_spreadsheets_controller.rb
@@ -5,7 +5,9 @@ class LogSpreadsheetsController < ApplicationController
   before_action :authenticate_user!
 
   def status
-    spreadsheet = LogSpreadsheet.find(params.require(:id))
+    # WARNING: note that 'file' field can be huge sometimes. Don't load it when it's not needed,
+    #          limit fields to 'status' and 'status_msg' only.
+    spreadsheet = LogSpreadsheet.select('status', 'status_msg').find(params.require(:id))
     render json: {status: spreadsheet.status, status_msg: spreadsheet.status_msg}
   end
 
@@ -16,6 +18,6 @@ class LogSpreadsheetsController < ApplicationController
       render nothing: true, status: 400
       return
     end
-    send_data spreadsheet.file.force_encoding('binary'), filename: "logs-#{spreadsheet.id}.csv", type: 'text/csv'
+    send_data spreadsheet.file, filename: "logs-#{spreadsheet.id}.csv", type: 'text/csv'
   end
 end

--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -1,7 +1,7 @@
 Delayed::Worker.destroy_failed_jobs = false
 Delayed::Worker.sleep_delay = 10
 Delayed::Worker.max_attempts = 2
-Delayed::Worker.max_run_time = 3.minutes
+Delayed::Worker.max_run_time = 45.minutes
 Delayed::Worker.default_queue_name = 'default'
 Delayed::Worker.delay_jobs = !Rails.env.test?
 Delayed::Worker.raise_signal_exceptions = :term

--- a/spec/models/log_spreadsheet_spec.rb
+++ b/spec/models/log_spreadsheet_spec.rb
@@ -54,7 +54,7 @@ describe LogSpreadsheet, :type => :model do
     it "generates spreadsheet which matches log data and query" do
       spreadsheet.generate
 
-      csv = CSV.new StringIO.new(spreadsheet.file), :headers => true
+      csv = CSV.new StringIO.new(spreadsheet.file_chunk), :headers => true
 
       logs_matching_query = Log.where(application: app.name).where(activity: "myActivity").where("extras -> :key IN ( :list )", :key => "groupname", :list => ["group1"]).order(id: :asc)
       expect(csv.count).to eql(logs_matching_query.count)
@@ -85,7 +85,7 @@ describe LogSpreadsheet, :type => :model do
       it "generates spreadsheet which matches log data and query" do
         spreadsheet.generate
 
-        csv = CSV.new StringIO.new(spreadsheet.file), :headers => true
+        csv = CSV.new StringIO.new(spreadsheet.file_chunk), :headers => true
 
         logs_matching_query = Log.where(application: app.name).where(activity: "myActivity").where("extras -> :key IN ( :list )", :key => "groupname", :list => ["group1"]).order(id: :asc)
         expect(csv.count).to eql(logs_matching_query.count)


### PR DESCRIPTION
Okay, so it was a bit more complicated than I thought... When I increased the limit and generated pretty big files, some new issues showed up:
1. `log_spreadsheets_controller#status` was loading the whole model each time, including the huge csv file that was being generated, so that was causing "memory quota exceeded" errors on heroku and basically killing the web worker. This is not surprising taking into account that we ask for status every 2 seconds.
2. `log_spreadsheets_controller#file` (which only serves generated cvb file) was also killing the web worker for large files (~200MB). Actually, I'm a bit surprised why (e.g. memory usage was growing from 300MB to 1.5GB for 200MB file).

I've fixed the first problem that by making `file` field inaccessible when the default scope is used. I know that the `default_scope` is usually thought to be a bad idea, but in this case it seems to make sense - you won't load huge file by accident. You can only use methods like `#file_chunk` which is using raw SQL again.

The second issue is fixed too - `log_spreadsheets_controller#file` is streaming data now and reading file in chunks (16MB as that feels safe in terms of mem usage and seems to be fast enough).

It all would be much simpler if we had access to the file system on heroku. :wink: Another option would be to stream data directly to S3 and then download from S3.

Note that's already deployed to production, as that was the only reasonable way to test it (I didn't touch basic logging functionality, so it felt safe enough).

Example:
JSON query (generates 436k rows, 200MB):

```
{
    "filter": [
        {
            "key": "time",
            "start_time": "",
            "end_time": "2015-05-01T00:00",
            "filter_type": "time"
        }
    ],
    "filter_having_keys": {
        "keys_list": []
    },
    "measures": [],
    "child_query": {
        "filter": [],
        "add_child_data": true
    }
}
```

No errors, mem usage from heroku:
- web-worker ![web](https://cloud.githubusercontent.com/assets/767857/11406607/7b4b47fa-93ae-11e5-89d0-fe3a926aa9ec.png)
- worker ![worker](https://cloud.githubusercontent.com/assets/767857/11406610/824d7730-93ae-11e5-9003-a264e3749723.png)
