### PR TITLE
Delay removing spreadsheets until after generation

### DIFF
--- a/app/jobs/spreadsheet_export_job.rb
+++ b/app/jobs/spreadsheet_export_job.rb
@@ -9,6 +9,7 @@ class SpreadsheetExportJob < Struct.new(:log_spreadsheet_id)
 
   def success(job)
     update_status(LogSpreadsheet::STATUS_SUCCEED, 'Export generated.')
+    LogSpreadsheet.remove_old_spreadsheets
   end
 
   def error(job, exception)

--- a/spec/models/log_spreadsheet_spec.rb
+++ b/spec/models/log_spreadsheet_spec.rb
@@ -7,8 +7,8 @@ describe LogSpreadsheet, :type => :model do
       count = LogSpreadsheet::SPREADSHEET_COUNT_LIMIT + 10
       count.times do
         FactoryGirl.create(:log_spreadsheet)
-        expect(LogSpreadsheet.count).to be <= LogSpreadsheet::SPREADSHEET_COUNT_LIMIT
       end
+      LogSpreadsheet.remove_old_spreadsheets
       expect(LogSpreadsheet.count).to eql(LogSpreadsheet::SPREADSHEET_COUNT_LIMIT)
     end
   end


### PR DESCRIPTION
Also fix potential error when removing them.

Tests fixed, `destroy_all` added.

(Weird. If you manually close a PR, and then force-push the branch to rebase some changes, you're not allowed to re-open that same PR.)