### PR TITLE
Fix an issue with spring in our docker setup

### DIFF
--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -18,6 +18,17 @@ WORKDIR $APP_HOME
 RUN apt-get update && apt-get install -y npm
 
 #
+# update bundler since version in rails:4.1 is older
+#
+RUN gem install bundler
+
+#
+# Spring has a bug where it doesn't respect BUNDLER environment variables
+# https://github.com/rails/spring/issues/339
+#
+ADD docker/dev/spring.rb /root/.spring.rb
+
+#
 # Expose UI port
 #
 EXPOSE 3000

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -238,7 +238,7 @@ GEM
     simple_form (3.0.2)
       actionpack (~> 4.0)
       activemodel (~> 4.0)
-    spring (1.1.3)
+    spring (1.7.2)
     spring-commands-rspec (1.0.4)
       spring (>= 0.9.1)
     sprockets (2.11.0)

--- a/bin/rails
+++ b/bin/rails
@@ -1,7 +1,8 @@
 #!/usr/bin/env ruby
 begin
-  load File.expand_path("../spring", __FILE__)
-rescue LoadError
+  load File.expand_path('../spring', __FILE__)
+rescue LoadError => e
+  raise unless e.message.include?('spring')
 end
 APP_PATH = File.expand_path('../../config/application',  __FILE__)
 require_relative '../config/boot'

--- a/bin/rspec
+++ b/bin/rspec
@@ -4,6 +4,5 @@ begin
 rescue LoadError => e
   raise unless e.message.include?('spring')
 end
-require_relative '../config/boot'
-require 'rake'
-Rake.application.run
+require 'bundler/setup'
+load Gem.bin_path('rspec-core', 'rspec')

--- a/bin/spring
+++ b/bin/spring
@@ -1,18 +1,15 @@
 #!/usr/bin/env ruby
 
-# This file loads spring without using Bundler, in order to be fast
-# It gets overwritten when you run the `spring binstub` command
+# This file loads spring without using Bundler, in order to be fast.
+# It gets overwritten when you run the `spring binstub` command.
 
 unless defined?(Spring)
-  require "rubygems"
-  require "bundler"
+  require 'rubygems'
+  require 'bundler'
 
-  if match = Bundler.default_lockfile.read.match(/^GEM$.*?^    spring \((.*?)\)$.*?^$/m)
-    ENV["GEM_PATH"] = ([Bundler.bundle_path.to_s] + Gem.path).join(File::PATH_SEPARATOR)
-    ENV["GEM_HOME"] = ""
-    Gem.paths = ENV
-
-    gem "spring", match[1]
-    require "spring/binstub"
+  if (match = Bundler.default_lockfile.read.match(/^GEM$.*?^    (?:  )*spring \((.*?)\)$.*?^$/m))
+    Gem.paths = { 'GEM_PATH' => [Bundler.bundle_path.to_s, *Gem.path].uniq.join(Gem.path_separator) }
+    gem 'spring', match[1]
+    require 'spring/binstub'
   end
 end

--- a/docker/dev/spring.rb
+++ b/docker/dev/spring.rb
@@ -1,0 +1,5 @@
+# this is a hack to work around a bug in spring:
+# https://github.com/rails/spring/issues/339
+# There is a PR to fix it here:
+# https://github.com/rails/spring/pull/546
+ENV['BUNDLE_PATH'] = '/bundle'


### PR DESCRIPTION
This code also updates spring and bundler.

The issue is that spring is not picking up the BUNDLE_HOME env variable set by
Dockerfile-dev The result is that running rails commands fail with an error:
```
git://github.com/rweng/jquery-datatables-rails.git (at master) is not yet checked out. Run `bundle install` first.
```
But according to bundler everything looks fine.

The spring issue is caused by a bug in spring, reported here:
https://github.com/rails/spring/issues/545
https://github.com/rails/spring/issues/339
With a suggested fix here:
https://github.com/rails/spring/pull/546
However the fix is failing the spring travis tests.

The work around in this commit manually sets the the ENV variable in ~/.spring.rb

We use BUNDLE_HOME so all of the gems downloaded by bundler are stored outside of the Docker image. This way changes to the docker image don't require downloading all of the gems again.